### PR TITLE
allow tunneling more than one port

### DIFF
--- a/tunnels.py
+++ b/tunnels.py
@@ -31,8 +31,7 @@ def cli(stack_name, ports, jump_host, region, user):
     try:
         portlist = parse_ports(ports)
     except ValueError:
-        print('Could not parse ports: ' + ports)
-        return
+        raise click.UsageError('Could not parse ports: ' + ports)
 
     senza_cmd = ['senza', 'instances', '--output=json', stack_name]
     if region:


### PR DESCRIPTION
Allow tunneling of lists of ports/port ranges, e.g.

```
./tunnels.py my_stack 8083,8090-8099,9040 odd-eu-west-1.my-team.zalan.do --region eu-west-1
```
