### PR TITLE
Add install instructions based of #10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,7 @@ Installation
 
 .. code-block:: bash
 
-    $ git clone https://github.com/zalando-stups/ssh-tunnels.git
-    $ cd ssh-tunnels
-    $ sudo python3 setup.py install # remove "sudo" if you have user-local Python setup
+    $ sudo pip3 install --upgrade stups-ssh-tunnels
 
 Usage
 =====


### PR DESCRIPTION
Package now exists on PyPI. No need to clone the repo
and execute setup.py any more to install.

Readme update with new instructions.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>